### PR TITLE
Stop junit test from failing

### DIFF
--- a/quartz/src/test/java/org/quartz/VersionTest.java
+++ b/quartz/src/test/java/org/quartz/VersionTest.java
@@ -20,7 +20,7 @@ import junit.framework.TestCase;
 
 import org.quartz.core.QuartzScheduler;
 
-public class VersionTest extends TestCase {
+public class VersionTest /*extends TestCase*/ {
 //    private static final String SNAPSHOT_SUFFIX = "-atlassian-1-SNAPSHOT";
 
 //    public void testVersionParsing() {


### PR DESCRIPTION
comment out extends test case as this fails due to no tests being present